### PR TITLE
Add auto ami build

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,19 +1,25 @@
 name: master
 
 on:
-  push:
-    branches: [ master ]
+
   pull_request:
     branches: [ master ]
 
 jobs:
-  build:
 
+  strategy:
+    max-parallel: 1
+
+  build:
     runs-on: ubuntu-latest
-    container: slacgismo/gridlabd_dockerhub_base:201217
+    container: hipas/gridlabd_dockerhub_base:201217
 
     steps:
     - uses: actions/checkout@v2
+    - name: Set Git config
+      run: |
+        git config --local user.email "actions@github.com"
+        git config --local user.name "Github Actions"
     - name: Update python3 modules
       run: pip3 install -r requirements.txt
     - name: Install openfido
@@ -29,9 +35,78 @@ jobs:
         gridlabd -D keep_progress=TRUE -T 0 --validate || ( utilities/save_validation_errors ; false )
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
+
       if: failure()
       with:
         name: validate-result
         path: |
           validate.txt
           validate.tar.gz
+
+  release:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    
+    steps:
+    - name: Create Release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # using github repo secrets... see: https://docs.github.com/en/actions/reference/encrypted-secrets
+        RELEASE_NAME: ${{ secrets.RELEASE_NAME }}
+        RELEASE_VERSION: ${{ secrets.RELEASE_VERSION }}
+        RELEASE_BODY: ${{ github.event.pull_request.body }}
+      run: |
+        chmod +x ./create_release.sh
+        ./create_release.sh -v "$RELEASE_VERSION" -n "$RELEASE_NAME" -b "$RELEASE_BODY"
+    - name: Merge master back to dev
+      run: |
+        git fetch --unshallow
+        git checkout develop
+        git pull
+        git merge main -m "Auto-merge master back to develop"
+        git push
+    - name: Update docker tag
+      env:
+        DOCKER_TAG: ${{ secrets.DOCKER_TAG }}
+        DOCKER_USER: ${{ secrets.DOCKER_USER }}
+        DOCKER_PASS: ${{ secrets.DOCKER_PASS }}
+      run: |
+        echo "$DOCKER_PASS" | docker login --username "$DOCKER_USER" --password-stdin
+        docker pull avpeery/helloworld
+        docker tag avpeery/helloworld avpeery/helloworld:${{ env.DOCKER_TAG }}
+        docker push avpeery/helloworld:${{ env.DOCKER_TAG }}
+    - name: Build new AMI for this release
+      env:
+        IMAGE_NAME: ${{ secrets.IMAGE_NAME }}
+        REGION: ${{ secrets.AWS_REGION }}
+        TOPIC: ${{ secrets.AWS_TOPIC }}
+        AWS_ACCESS_ID: ${{ secrets.AWS_ACCESS_ID }}
+        AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
+      run: |
+        chmod +x ./update_ec2.sh
+        ./update_ec2.sh -v "$IMAGE_NAME"
+    - name: Set up Cloud SDK
+      uses: google-github-actions/setup-gcloud@master
+      with:
+        project_id: ${{ secrets.GCP_PROJECT_ID }}
+        service_account_key: ${{ secrets.GCP_SA_KEY }}
+        export_default_credentials: true
+    - name: Start GCP instance
+      run:
+        gcloud compute instances start hipas --zone us-west1-b
+    - name: Update GCP VM instance
+      env:
+        IMAGE_NAME: ${{ secrets.IMAGE_NAME }}
+      run:
+        gcloud pubsub topics publish hipas-instance-update --message=${{ env.IMAGE_NAME }}
+    - name: Sleep for 30s # wait for update GCP VM instance to complete
+      uses: jakejarvis/wait-action@master
+      with:
+        time: '30s'
+    - name: Stop GCP VM instance
+      run:
+        gcloud compute instances stop hipas --zone us-west1-b
+    - name: Update GCP Image
+      env:
+        IMAGE_NAME: ${{ secrets.IMAGE_NAME }}
+      run:
+        gcloud compute images create ${{ env.IMAGE_NAME }} --source-disk=hipas --source-disk-zone=us-west1-b

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -55,14 +55,14 @@ jobs:
           RELEASE_VERSION: ${{ secrets.RELEASE_VERSION }}
           RELEASE_BODY: ${{ github.event.pull_request.body }}
         run: |
-          chmod +x ./create_release.sh
-          ./create_release.sh -v "$RELEASE_VERSION" -n "$RELEASE_NAME" -b "$RELEASE_BODY"
+          chmod +x ./cloud/scripts/release.sh
+          ./cloud/scripts/release.sh -v "$RELEASE_VERSION" -n "$RELEASE_NAME" -b "$RELEASE_BODY"
       - name: Merge master back to dev
         run: |
           git fetch --unshallow
           git checkout develop
           git pull
-          git merge main -m "Auto-merge master back to develop"
+          git merge master -m "Auto-merge master back to develop"
           git push
       - name: Update docker tag
         env:
@@ -82,8 +82,7 @@ jobs:
           AWS_ACCESS_ID: ${{ secrets.AWS_ACCESS_ID }}
           AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
         run: |
-          chmod +x ./update_ec2.sh
-          ./update_ec2.sh -v "$IMAGE_NAME"
+          AWS_ACCESS_KEY_ID="$AWS_ACCESS_ID" AWS_SECRET_ACCESS_KEY="$AWS_SECRET_KEY" aws sns publish --region "$REGION" --topic-arn "$TOPIC" --message "$IMAGE_NAME"
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@master
         with:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -8,7 +8,7 @@ on:
 jobs:
 
   strategy:
-    max-parallel: 1
+    max-parallel: 1 # forces jobs to run sequentially
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -10,103 +10,103 @@ jobs:
   strategy:
     max-parallel: 1 # forces jobs to run sequentially
 
-  build:
-    runs-on: ubuntu-latest
-    container: hipas/gridlabd_dockerhub_base:201217
+    build:
+      runs-on: ubuntu-latest
+      container: hipas/gridlabd_dockerhub_base:201217
 
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set Git config
-      run: |
-        git config --local user.email "actions@github.com"
-        git config --local user.name "Github Actions"
-    - name: Update python3 modules
-      run: pip3 install -r requirements.txt
-    - name: Install openfido
-      run: curl -sL https://raw.githubusercontent.com/openfido/cli/main/install.sh | bash
-    - name: Run autoconf
-      run: autoreconf -isf
-    - name: Configure build
-      run: ./configure
-    - name: Build gridlabd
-      run: make -j10 system
-    - name: Validate build
-      run: |
-        gridlabd -D keep_progress=TRUE -T 0 --validate || ( utilities/save_validation_errors ; false )
-    - name: Upload artifacts
-      uses: actions/upload-artifact@v2
+      steps:
+      - uses: actions/checkout@v2
+      - name: Set Git config
+        run: |
+          git config --local user.email "actions@github.com"
+          git config --local user.name "Github Actions"
+      - name: Update python3 modules
+        run: pip3 install -r requirements.txt
+      - name: Install openfido
+        run: curl -sL https://raw.githubusercontent.com/openfido/cli/main/install.sh | bash
+      - name: Run autoconf
+        run: autoreconf -isf
+      - name: Configure build
+        run: ./configure
+      - name: Build gridlabd
+        run: make -j10 system
+      - name: Validate build
+        run: |
+          gridlabd -D keep_progress=TRUE -T 0 --validate || ( utilities/save_validation_errors ; false )
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
 
-      if: failure()
-      with:
-        name: validate-result
-        path: |
-          validate.txt
-          validate.tar.gz
+        if: failure()
+        with:
+          name: validate-result
+          path: |
+            validate.txt
+            validate.tar.gz
 
-  release:
-    runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true
-    
-    steps:
-    - name: Create Release
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # using github repo secrets... see: https://docs.github.com/en/actions/reference/encrypted-secrets
-        RELEASE_NAME: ${{ secrets.RELEASE_NAME }}
-        RELEASE_VERSION: ${{ secrets.RELEASE_VERSION }}
-        RELEASE_BODY: ${{ github.event.pull_request.body }}
-      run: |
-        chmod +x ./create_release.sh
-        ./create_release.sh -v "$RELEASE_VERSION" -n "$RELEASE_NAME" -b "$RELEASE_BODY"
-    - name: Merge master back to dev
-      run: |
-        git fetch --unshallow
-        git checkout develop
-        git pull
-        git merge main -m "Auto-merge master back to develop"
-        git push
-    - name: Update docker tag
-      env:
-        DOCKER_TAG: ${{ secrets.DOCKER_TAG }}
-        DOCKER_USER: ${{ secrets.DOCKER_USER }}
-        DOCKER_PASS: ${{ secrets.DOCKER_PASS }}
-      run: |
-        echo "$DOCKER_PASS" | docker login --username "$DOCKER_USER" --password-stdin
-        docker pull avpeery/helloworld
-        docker tag avpeery/helloworld avpeery/helloworld:${{ env.DOCKER_TAG }}
-        docker push avpeery/helloworld:${{ env.DOCKER_TAG }}
-    - name: Build new AMI for this release
-      env:
-        IMAGE_NAME: ${{ secrets.IMAGE_NAME }}
-        REGION: ${{ secrets.AWS_REGION }}
-        TOPIC: ${{ secrets.AWS_TOPIC }}
-        AWS_ACCESS_ID: ${{ secrets.AWS_ACCESS_ID }}
-        AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
-      run: |
-        chmod +x ./update_ec2.sh
-        ./update_ec2.sh -v "$IMAGE_NAME"
-    - name: Set up Cloud SDK
-      uses: google-github-actions/setup-gcloud@master
-      with:
-        project_id: ${{ secrets.GCP_PROJECT_ID }}
-        service_account_key: ${{ secrets.GCP_SA_KEY }}
-        export_default_credentials: true
-    - name: Start GCP instance
-      run:
-        gcloud compute instances start hipas --zone us-west1-b
-    - name: Update GCP VM instance
-      env:
-        IMAGE_NAME: ${{ secrets.IMAGE_NAME }}
-      run:
-        gcloud pubsub topics publish hipas-instance-update --message=${{ env.IMAGE_NAME }}
-    - name: Sleep for 30s # wait for update GCP VM instance to complete
-      uses: jakejarvis/wait-action@master
-      with:
-        time: '30s'
-    - name: Stop GCP VM instance
-      run:
-        gcloud compute instances stop hipas --zone us-west1-b
-    - name: Update GCP Image
-      env:
-        IMAGE_NAME: ${{ secrets.IMAGE_NAME }}
-      run:
-        gcloud compute images create ${{ env.IMAGE_NAME }} --source-disk=hipas --source-disk-zone=us-west1-b
+    release:
+      runs-on: ubuntu-latest
+      if: github.event.pull_request.merged == true
+      
+      steps:
+      - name: Create Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # using github repo secrets... see: https://docs.github.com/en/actions/reference/encrypted-secrets
+          RELEASE_NAME: ${{ secrets.RELEASE_NAME }}
+          RELEASE_VERSION: ${{ secrets.RELEASE_VERSION }}
+          RELEASE_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          chmod +x ./create_release.sh
+          ./create_release.sh -v "$RELEASE_VERSION" -n "$RELEASE_NAME" -b "$RELEASE_BODY"
+      - name: Merge master back to dev
+        run: |
+          git fetch --unshallow
+          git checkout develop
+          git pull
+          git merge main -m "Auto-merge master back to develop"
+          git push
+      - name: Update docker tag
+        env:
+          DOCKER_TAG: ${{ secrets.DOCKER_TAG }}
+          DOCKER_USER: ${{ secrets.DOCKER_USER }}
+          DOCKER_PASS: ${{ secrets.DOCKER_PASS }}
+        run: |
+          echo "$DOCKER_PASS" | docker login --username "$DOCKER_USER" --password-stdin
+          docker pull hipas/gridlabd
+          docker tag hipas/gridlabd hipas/gridlabd:${{ env.DOCKER_TAG }}
+          docker push hipas/gridlabd:${{ env.DOCKER_TAG }}
+      - name: Build new AMI for this release
+        env:
+          IMAGE_NAME: ${{ secrets.IMAGE_NAME }}
+          REGION: ${{ secrets.AWS_REGION }}
+          TOPIC: ${{ secrets.AWS_TOPIC }}
+          AWS_ACCESS_ID: ${{ secrets.AWS_ACCESS_ID }}
+          AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
+        run: |
+          chmod +x ./update_ec2.sh
+          ./update_ec2.sh -v "$IMAGE_NAME"
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@master
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          export_default_credentials: true
+      - name: Start GCP instance
+        run:
+          gcloud compute instances start hipas --zone us-west1-b
+      - name: Update GCP VM instance
+        env:
+          IMAGE_NAME: ${{ secrets.IMAGE_NAME }}
+        run:
+          gcloud pubsub topics publish hipas-instance-update --message=${{ env.IMAGE_NAME }}
+      - name: Sleep for 30s # wait for update GCP VM instance to complete
+        uses: jakejarvis/wait-action@master
+        with:
+          time: '30s'
+      - name: Stop GCP VM instance
+        run:
+          gcloud compute instances stop hipas --zone us-west1-b
+      - name: Update GCP Image
+        env:
+          IMAGE_NAME: ${{ secrets.IMAGE_NAME }}
+        run:
+          gcloud compute images create ${{ env.IMAGE_NAME }} --source-disk=hipas --source-disk-zone=us-west1-b

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -110,3 +110,4 @@ jobs:
           IMAGE_NAME: ${{ secrets.IMAGE_NAME }}
         run:
           gcloud compute images create ${{ env.IMAGE_NAME }} --source-disk=hipas --source-disk-zone=us-west1-b
+          

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -109,5 +109,4 @@ jobs:
         env:
           IMAGE_NAME: ${{ secrets.IMAGE_NAME }}
         run:
-          gcloud compute images create ${{ env.IMAGE_NAME }} --source-disk=hipas --source-disk-zone=us-west1-b
-          
+          gcloud compute images create ${{ env.IMAGE_NAME }} --source-disk=hipas --source-disk-zone=us-west1-

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -16,10 +16,6 @@ jobs:
 
       steps:
       - uses: actions/checkout@v2
-      - name: Set Git config
-        run: |
-          git config --local user.email "actions@github.com"
-          git config --local user.name "Github Actions"
       - name: Update python3 modules
         run: pip3 install -r requirements.txt
       - name: Install openfido
@@ -44,10 +40,15 @@ jobs:
             validate.tar.gz
 
     release:
-      runs-on: ubuntu-latest
       if: github.event.pull_request.merged == true
-      
+      needs: build
+      runs-on: ubuntu-latest
       steps:
+      - uses: actions/checkout@v2
+      - name: Set Git config
+        run: |
+          git config --local user.email "actions@github.com"
+          git config --local user.name "Github Actions"
       - name: Create Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # using github repo secrets... see: https://docs.github.com/en/actions/reference/encrypted-secrets

--- a/cloud/scripts/release.sh
+++ b/cloud/scripts/release.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+while getopts ":v:n:b:" flag
+do
+  case "${flag}"
+    in
+      v) 
+        RELEASE_VERSION=${OPTARG}
+        ;;
+      n)
+        RELEASE_NAME=${OPTARG}
+        ;;
+      b)
+        RELEASE_BODY=${OPTARG}
+        ;;
+    esac
+done
+shift $((OPTIND-1))
+
+DRAFT="false"
+PRE="false"
+BRANCH="master"
+
+API_JSON=$(printf '{"tag_name": "v%s","target_commitish": "%s","name": "%s","body": "%s","draft": %s,"prerelease": %s}' "$RELEASE_VERSION" "$BRANCH" "$RELEASE_NAME" "$RELEASE_BODY" "$DRAFT" "$PRE" )
+
+#creates the release and publishes
+API_RELEASE_RESPONSE=$(curl  -H "Authorization: token $GITHUB_TOKEN" --data "$API_JSON" -s -i https://api.github.com/repos/hipas/gridlabd/releases)
+
+echo "$API_RELEASE_RESPONSE"


### PR DESCRIPTION
## Current issues
1. Process to create new release is manually completed
2. Needs to auto build AWS AMI and GCP VM images
3. Develop modifications still execute master.yml actions - FIX 

## Code changes
- [x] Changes to master.yml for github actions - add workflow to auto create new release, tag docker image, and auto build new AWS AMI and GCP VM Images.
- [x] Need to ensure second job only runs after successful completion of the first
- [x] Relies heavily on github secrets - ensure secrets are updated for hipas account

