### PR TITLE
replaced slacgismo links with hipas references for github and docker

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 ## Important Notice
 
-This repository is a fork of the official version of GridLAB-D.  To make contributions to that version, see the PNNL-managed GitHub repository at https://github.com/gridlab-d/gridlab-d].
+This repository is a fork of the official version of GridLAB-D.  To make contributions to that version, see the PNNL-managed GitHub repository at https://github.com/gridlab-d/gridlab-d.
 
 Authorized github users may contribute to this repository. You must be a Stanford faculty, staff, student, affiliate, or subcontractor to be a contributor.  Please contact the repository owner to be authorized as a contributor.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ _Note_: When a merge is performed, the PR is automatically closed and the branch
 
 ## Documentation changes
 
-All documentation changes arising from new features and capabilities should be made to this repository's wiki pages at https://github.com/slacgismo/gridlabd/wiki. Fixes or correction to GridLAB-D's online documentation should be made to https://gridlab-d.shoutwiki.org/, subject to review and approval by the PNNL team.
+All documentation changes arising from new features and capabilities should be made to this repository's wiki pages at https://github.com/hipas/gridlabd/wiki. Fixes or correction to GridLAB-D's online documentation should be made to https://gridlab-d.shoutwiki.org/, subject to review and approval by the PNNL team.
 
 # Coding Conventions
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Chassin, D.P., et al., "GridLAB-D Version _major_._minor_._patch_-_build_ (_bran
 You may use the `--cite` command option to obtain the correct citation for your version:
 ~~~
 host% gridlabd --cite
-Chassin, D.P., et al. "GridLAB-D 4.2.0-191008 (fix_python_validate) DARWIN", (2019) [online]. Available at https://github.com/hipas/gridlabd/commit/dfc392dc0208419ce9be0706f699fdd9a11e3f5b, Accessed on: Oct. 8, 2019.
+Chassin, D.P., et al. "GridLAB-D 4.2.0-191008 (fix_python_validate) DARWIN", (2019) [online]. Available at https://github.com/slacgismo/gridlabd/commit/dfc392dc0208419ce9be0706f699fdd9a11e3f5b, Accessed on: Oct. 8, 2019.
 ~~~
 This will allow anyone to identify the exact version you are using to obtain it from GitHub.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![master](https://github.com/dchassin/gridlabd/workflows/master/badge.svg) ![develop](https://github.com/slacgismo/gridlabd/workflows/develop/badge.svg?branch=develop)
+![master](https://github.com/dchassin/gridlabd/workflows/master/badge.svg) ![develop](https://github.com/hipas/gridlabd/workflows/develop/badge.svg?branch=develop)
 
 The documentation for this project is located at http://docs.gridlabd.us/.
 
@@ -20,25 +20,25 @@ The following projects are actively contributing to HiPAS GridLAB-D at this time
 
 # User quick start
 
-The preferred method for running HiPAS GridLAB-D is to download the SLAC master image from docker hub (see https://cloud.docker.com/u/gridlabd/repository/docker/gridlabd/slac-master).  You must install the docker daemon to use docker images.  See https://www.docker.com/get-started for details.
+The preferred method for running HiPAS GridLAB-D is to download the SLAC master image from docker hub (see https://cloud.docker.com/u/gridlabd/repository/docker/hipas/gridlabd).  You must install the docker daemon to use docker images.  See https://www.docker.com/get-started for details.
 
 Once you have installed docker, you may issue the following commands to run GridLAB-D at the command line:
 ~~~
-  host% docker run -it -v $PWD:/model gridlabd/slac-master gridlabd -W /model [load-options] [filename.glm] [run-options] 
+  host% docker run -it -v $PWD:/model hipas/gridlabd gridlabd -W /model [load-options] [filename.glm] [run-options] 
 ~~~ 
 On many systems, an alias can be used to make this a simple command that resemble the command you would normally issue to run a host-based installation:
 ~~~
-  host% alias gridlabd='docker run -it -v $PWD:/model gridlabd/slac-master gridlabd -W /model'
+  host% alias gridlabd='docker run -it -v $PWD:/model hipas/gridlabd gridlabd -W /model'
 ~~~
 Note that this alias will interfere with the host-based installation.
 
 # Developer quick start
 
-*Note*: This fork of [GridLAB-D](https://github.com/gridlab-d/gridlab-d) does not support MS Windows directly. You must use docker or a virtual machine running linux.
+*Note*: This fork of [GridLAB-D](https://github.com/hipas/gridlabd) does not support MS Windows directly. You must use docker or a virtual machine running linux.
 
 Normally on Linux and Mac OS X developers should use the `install.sh` script to setup the system, perform the initial build, and install GridLAB-D for all users on the system. 
 ~~~
-host% git clone https://github.com/slacgismo/gridlabd gridlabd
+host% git clone https://github.com/hipas/gridlabd gridlabd
 host% gridlabd/install.sh
 ~~~
 
@@ -48,7 +48,7 @@ If you have modified the branch name or version information, you must reconfigur
 
 Each build of HiPAS GridLAB-D will be installed in `/usr/local/opt/gridlabd`. Links to the active version are added to the `/usr/local/bin` folder, so this folder must be included in the path for all users, e.g., as specified in `/etc/profile` or `/etc/profile.d`. Additional links are created in `/usr/local/lib` and `/usr/local/share`, as needed. 
 
-You may use the `gridlabd version` command to manage which version is active on the system. See the [`gridlabd version`](http://docs.gridlabd.us/index.html?owner=slacgismo&project=gridlabd&branch=master&folder=/Subcommand&doc=/Subcommand/Version.md) command for details.
+You may use the `gridlabd version` command to manage which version is active on the system. See the [`gridlabd version`](http://docs.gridlabd.us/index.html?owner=hipas&project=gridlabd&branch=master&folder=/Subcommand&doc=/Subcommand/Version.md) command for details.
 
 You use `make install` to build only. To use an inactive build run the `gridlabd` command of that build instead of running the active version.  For example, if you only built `4.2.13-201019-develop` then you can run `/usr/local/opt/gridlabd/4.2.13-201019-develop/bin/gridlabd` to run it instead of running `/usr/local/bin/gridlabd`.
 
@@ -56,7 +56,7 @@ Before using a build of gridlabd, you should always validate it using `gridlabd 
 
 ## Building and Debugging
 
-You can configure a debugging version using `make reconfigure-debug`.  When debugging is enabled you can use the [`gridlabd trace`](http://docs.gridlabd.us/index.html?owner=slacgismo&project=gridlabd&branch=master&folder=/Subcommand&doc=/Subcommand/Trace.md) command and the [`gridlabd gdb`](http://docs.gridlabd.us/index.html?owner=slacgismo&project=gridlabd&branch=master&folder=/Subcommand&doc=/Subcommand/Gdb.md) (for linux) or [`gridlabd lldb`](http://docs.gridlabd.us/index.html?owner=slacgismo&project=gridlabd&branch=master&folder=/Subcommand&doc=/Subcommand/Lldb.md) (for Mac OSX) commands to debug a simulation.
+You can configure a debugging version using `make reconfigure-debug`.  When debugging is enabled you can use the [`gridlabd trace`](http://docs.gridlabd.us/index.html?owner=hipas&project=gridlabd&branch=master&folder=/Subcommand&doc=/Subcommand/Trace.md) command and the [`gridlabd gdb`](http://docs.gridlabd.us/index.html?owner=hipas&project=gridlabd&branch=master&folder=/Subcommand&doc=/Subcommand/Gdb.md) (for linux) or [`gridlabd lldb`](http://docs.gridlabd.us/index.html?owner=hipas&project=gridlabd&branch=master&folder=/Subcommand&doc=/Subcommand/Lldb.md) (for Mac OSX) commands to debug a simulation.
 
 ## Notes
 - The version number should contain the _branch-name_.  If not, use the `which gridlabd` command to check that the path is correct.
@@ -80,10 +80,10 @@ Chassin, D.P., et al., "GridLAB-D Version _major_._minor_._patch_-_build_ (_bran
 You may use the `--cite` command option to obtain the correct citation for your version:
 ~~~
 host% gridlabd --cite
-Chassin, D.P., et al. "GridLAB-D 4.2.0-191008 (fix_python_validate) DARWIN", (2019) [online]. Available at https://github.com/slacgismo/gridlabd/commit/dfc392dc0208419ce9be0706f699fdd9a11e3f5b, Accessed on: Oct. 8, 2019.
+Chassin, D.P., et al. "GridLAB-D 4.2.0-191008 (fix_python_validate) DARWIN", (2019) [online]. Available at https://github.com/hipas/gridlabd/commit/dfc392dc0208419ce9be0706f699fdd9a11e3f5b, Accessed on: Oct. 8, 2019.
 ~~~
 This will allow anyone to identify the exact version you are using to obtain it from GitHub.
 
 ## Contributions
 
-Please see https://github.com/slacgismo/gridlabd/blob/master/CONTRIBUTING.md for information on making contributions to this repository.
+Please see https://github.com/hipas/gridlabd/blob/master/CONTRIBUTING.md for information on making contributions to this repository.

--- a/cloud/websites/code.gridlabd.us/index.html
+++ b/cloud/websites/code.gridlabd.us/index.html
@@ -1,8 +1,8 @@
 <HTML>
 <HEAD>
-<META HTTP-EQUIV="refresh" CONTENT="0,url=https://github.com/slacgismo/gridlabd" />
+<META HTTP-EQUIV="refresh" CONTENT="0,url=https://github.com/hipas/gridlabd" />
 </HEAD>
 <BODY>
-Redirecting to <A HREF="https://github.com/slacgismo/gridlabd">https://github.com/slacgismo/gridlabd</A>...
+Redirecting to <A HREF="https://github.com/hipas/gridlabd">https://github.com/hipas/gridlabd</A>...
 </BODY>
 </HTML>

--- a/cloud/websites/docs.gridlabd.us/index.html
+++ b/cloud/websites/docs.gridlabd.us/index.html
@@ -1,8 +1,8 @@
 <HTML>
 <HEAD>
-<META HTTP-EQUIV="refresh" CONTENT="0,url=http://docs.slacgismo.org/index.html?owner=slacgismo&project=gridlabd" />
+<META HTTP-EQUIV="refresh" CONTENT="0,url=http://docs.gridlabd.us/index.html?owner=hipas&project=gridlabd" />
 </HEAD>
 <BODY>
-Redirecting to <A HREF="http://docs.slacgismo.org/index.html?owner=slacgismo&project=gridlabd">http://docs.slacgismo.org/index.html?owner=slacgismo&project=gridlabd</A>...
+Redirecting to <A HREF="http://docs.gridlabd.us/index.html?owner=hipas&project=gridlabd">http://docs.gridlabd.us/index.html?owner=hipas&project=gridlabd</A>...
 </BODY>
 </HTML>

--- a/cloud/websites/status.gridlabd.us/active.html
+++ b/cloud/websites/status.gridlabd.us/active.html
@@ -96,7 +96,7 @@
 
             start = new Date(prompt("Enter report start date (yyyy-mm-dd): ",stop.getFullYear() + "-" + (stop.getMonth()+1) + "-01"));
 
-            r = run_query("/repos/slacgismo/gridlabd/issues?state=open&per_page=100&sort=updated&direction=asc&since="+start+"T00:00:00Z");
+            r = run_query("/repos/hipas/gridlabd/issues?state=open&per_page=100&sort=updated&direction=asc&since="+start+"T00:00:00Z");
             item_number = 1;
             if ( r.status == 200 )
             {
@@ -154,7 +154,7 @@
                             if ( start <= closed_dt && closed_dt <= stop )
                             {
                                 // console.info("*** output ***");
-                                report += "\n" + item_number + ". " + title + " ([" + number + "](https://github.com/slacgismo/gridlabd/issues/" + number + ") updated " + updated_at.substring(0,updated_at.indexOf("T")) + ")\n";
+                                report += "\n" + item_number + ". " + title + " ([" + number + "](https://github.com/hipas/gridlabd/issues/" + number + ") updated " + updated_at.substring(0,updated_at.indexOf("T")) + ")\n";
                                 // report += "Opened " + created_at.substring(0,created_at.indexOf("T")) + "\n";
                                 //report += "\n" + body + "\n\n";
                                 count += 1;

--- a/cloud/websites/status.gridlabd.us/issues-open.html
+++ b/cloud/websites/status.gridlabd.us/issues-open.html
@@ -94,7 +94,7 @@
                 set_default("token",token);
             }
 
-            r = run_query("/repos/slacgismo/gridlabd/issues?state=open&per_page=100&sort=updated&direction=desc");
+            r = run_query("/repos/hipas/gridlabd/issues?state=open&per_page=100&sort=updated&direction=desc");
             if ( r.status == 200 )
             {
                 report = "GridLAB-D Open Issues as of " + stop.getFullYear() + "-" + (stop.getMonth()+1) + "-" + stop.getDate() + "\n";

--- a/cloud/websites/status.gridlabd.us/pulls-closed.html
+++ b/cloud/websites/status.gridlabd.us/pulls-closed.html
@@ -95,7 +95,7 @@
 
             start = new Date(prompt("Enter report start date (yyyy-mm-dd): ",stop.getFullYear() + "-" + (stop.getMonth()+1) + "-01"));
 
-            r = run_query("/repos/slacgismo/gridlabd/pulls?state=closed&per_page=100&sort=updated&direction=desc");
+            r = run_query("/repos/hipas/gridlabd/pulls?state=closed&per_page=100&sort=updated&direction=desc");
             if ( r.status == 200 )
             {
                 report = "GridLAB-D Pull Requests Completed for period " + start.getFullYear() + "-" + (start.getMonth()+1) + "-" + start.getDate() + " - " + stop.getFullYear() + "-" + (stop.getMonth()+1) + "-" + stop.getDate() + "\n";

--- a/cloud/websites/status.gridlabd.us/pulls-open.html
+++ b/cloud/websites/status.gridlabd.us/pulls-open.html
@@ -94,7 +94,7 @@
                 set_default("token",token);
             }
 
-            r = run_query("/repos/slacgismo/gridlabd/pulls?state=open&per_page=100&sort=updated&direction=desc");
+            r = run_query("/repos/hipas/gridlabd/pulls?state=open&per_page=100&sort=updated&direction=desc");
             if ( r.status == 200 )
             {
                 report = "GridLAB-D Open Pull Requests as of " + stop.getFullYear() + "-" + (stop.getMonth()+1) + "-" + stop.getDate() + "\n";

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,8 @@
-FROM slacgismo/gridlabd_dockerhub_base:210211
+FROM hipas/gridlabd_dockerhub_base:210211
 
 
 ENV container docker
-ENV REPO=https://github.com/slacgismo/gridlabd
+ENV REPO=https://github.com/hipas/gridlabd
 ARG BRANCH
 RUN echo "Building $BRANCH"
 ENV ENABLE=gismo

--- a/docker/gridlabd.sh
+++ b/docker/gridlabd.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-REPO=${REPO:-https://github.com/slacgismo/gridlabd}
+REPO=${REPO:-https://github.com/hipas/gridlabd}
 BRANCH=${BRANCH:-master}
 echo "
 #####################################

--- a/docs/Cloud/AWS.md
+++ b/docs/Cloud/AWS.md
@@ -104,7 +104,7 @@ The following command connects to an EC2 instance and installs GridLAB-D:
 ~~~
 user@localhost$ ssh -i my-key.pem ec2-user@my-instance-ip
 ec2-user@my-instance-ip$ sudo yum install git -y
-ec2-user@my-instance-ip$ git clone https://github.com/slacgismo/gridlabd gridlabd
+ec2-user@my-instance-ip$ git clone https://github.com/hipas/gridlabd gridlabd
 ec2-user@my-instance-ip$ gridlabd/install.sh
 ~~~
 

--- a/docs/Command/Origin.md
+++ b/docs/Command/Origin.md
@@ -20,13 +20,13 @@ The following is the output for a clean build of a branch
 
 ~~~
 bash$ gridlabd --origin
-# https://github.com/slacgismo/gridlabd/commits/d2fca77b4985e28452e72e259ce6bf77d2d454b1
+# https://github.com/hipas/gridlabd/commits/d2fca77b4985e28452e72e259ce6bf77d2d454b1
 ~~~
 
 The following example includes diff output resulting from local changes to the code
 
 ~~~
-# https://github.com/slacgismo/gridlabd/commits/ff655ab92b650b2373d02b44bf884334d40faf06
+# https://github.com/hipas/gridlabd/commits/ff655ab92b650b2373d02b44bf884334d40faf06
 #  M gldcore/Makefile.mk
 #  M utilities/build_number
 # ?? utilities/update_origin.sh

--- a/docs/Developer/Install.md
+++ b/docs/Developer/Install.md
@@ -47,7 +47,7 @@ bash$ curl -L http://code.gridlabd.us/<branch>/install.sh | bash
 Manual installation is discouraged because the process is complex, highly error-prone, and varies widely from one platform to another.  However, it is necessary on platforms that are not supported by the automated installation script.  The general approach is roughly as follows, keeping in mind that the specific will vary from one system to another, and you may need to install certain tools and libraries to be successful.
 
 ~~~
-bash$ git clone https://github.com/slacgismo/gridlabd gridlabd
+bash$ git clone https://github.com/hipas/gridlabd gridlabd
 bash$ cd gridlabd
 bash$ autoreconf -isf
 bash$ ./configure

--- a/docs/Developers.md
+++ b/docs/Developers.md
@@ -1,13 +1,13 @@
-Software developers and engineers are welcome to contribute to HiPAS GridLAB-D. The source code to HiPAS is available to the public through the [GitHub SLAC Gismo GridLAB-D project](https://github.com/slacgismo/gridlabd). 
+Software developers and engineers are welcome to contribute to HiPAS GridLAB-D. The source code to HiPAS is available to the public through the [GitHub SLAC Gismo GridLAB-D project](https://github.com/hipas/gridlabd). 
 
 ## Developer Resources
 
-  - [Source code](https://github.com/slacgismo/gridlabd)
-  - [Issues](https://github.com/slacgismo/gridlabd/issues)
-  - [Pull requests](https://github.com/slacgismo/gridlabd/pulls)
-  - [Projects](https://github.com/slacgismo/gridlabd/projects)
-  - [Wiki](https://github.com/slacgismo/gridlabd)
-  - [Team Discussions](https://github.com/slacgismo/teams/gridlab-d/discussions)
+  - [Source code](https://github.com/hipas/gridlabd)
+  - [Issues](https://github.com/hipas/gridlabd/issues)
+  - [Pull requests](https://github.com/hipas/gridlabd/pulls)
+  - [Projects](https://github.com/hipas/gridlabd/projects)
+  - [Wiki](https://github.com/hipas/gridlabd)
+  - [Team Discussions](https://github.com/hipas/teams/gridlab-d/discussions)
 
 Developers should consult the [[/Developer/README]] for information about modifying and contributing to HiPAS GridLAB-D.
 
@@ -16,7 +16,7 @@ Developers should consult the [[/Developer/README]] for information about modify
 You can set up your system to host development and build GridLAB-D from source code using the installation script. 
 
 ~~~
-bash$ git clone https://github.com/slacgismo/gridlabd
+bash$ git clone https://github.com/hipas/gridlabd
 bash$ cd gridlabd
 bash$ ./install.sh
 ~~~

--- a/docs/GLM/Directive/Clock.md
+++ b/docs/GLM/Directive/Clock.md
@@ -52,4 +52,4 @@ clock {
 
 # See also
 
-* [share/tzinfo.txt](https://github.com/slacgismo/gridlabd/blob/master/gldcore/tzinfo.txt)
+* [share/tzinfo.txt](https://github.com/hipas/gridlabd/blob/master/gldcore/tzinfo.txt)

--- a/docs/Getting Started.md
+++ b/docs/Getting Started.md
@@ -1,7 +1,7 @@
 The preferred method for running GridLAB-D is using [Docker](www.docker.org).  Once you have installed Docker, you can run GridLAB-D as follows.
 
 ~~~
-bash% docker run -it slacgismo/gridlabd:latest gridlabd <filename>
+bash% docker run -it hipas/gridlabd:latest gridlabd <filename>
 ~~~
 
 where `<filename` is the name of the model file in the container that you wish to run.
@@ -9,7 +9,7 @@ where `<filename` is the name of the model file in the container that you wish t
 If you wish to access the files in the current folder while running GridLAB-D in a container, then use the command
 
 ~~~
-bash% docker run -vit $PWD:$PWD slacgismo/gridlabd:latest gridlabd -W $PWD <filename>
+bash% docker run -vit $PWD:$PWD hipas/gridlabd:latest gridlabd -W $PWD <filename>
 ~~~
 
 More information on using GridLAB-D docker containers can be found at [[/Install/Docker]].

--- a/docs/Global/Kmlhost.md
+++ b/docs/Global/Kmlhost.md
@@ -5,14 +5,14 @@
 GLM:
 
 ~~~
-#set kmlhost=https://raw.githubusercontent.com/slacgismo/gridlabd/master/gldcore/rt
+#set kmlhost=https://raw.githubusercontent.com/hipas/gridlabd/master/gldcore/rt
 ~~~
 
 Shell:
 
 ~~~
-bash$ gridlabd -D kmlhost=https://raw.githubusercontent.com/slacgismo/gridlabd/master/gldcore/rt
-bash$ gridlabd --define kmlhost=https://raw.githubusercontent.com/slacgismo/gridlabd/master/gldcore/rt
+bash$ gridlabd -D kmlhost=https://raw.githubusercontent.com/hipas/gridlabd/master/gldcore/rt
+bash$ gridlabd --define kmlhost=https://raw.githubusercontent.com/hipas/gridlabd/master/gldcore/rt
 ~~~
 
 # Description
@@ -22,5 +22,5 @@ KML server URL
 # Example
 
 ~~~
-#set kmlhost=https://raw.githubusercontent.com/slacgismo/gridlabd/master/gldcore/rt
+#set kmlhost=https://raw.githubusercontent.com/hipas/gridlabd/master/gldcore/rt
 ~~~

--- a/docs/Global/Tmp.md
+++ b/docs/Global/Tmp.md
@@ -5,14 +5,14 @@
 GLM:
 
 ~~~
-#set tmp=/Users/slacgismo/.gridlabd/tmp
+#set tmp=/Users/hipas/.gridlabd/tmp
 ~~~
 
 Shell:
 
 ~~~
-bash$ gridlabd -D tmp=/Users/slacgismo/.gridlabd/tmp
-bash$ gridlabd --define tmp=/Users/slacgismo/.gridlabd/tmp
+bash$ gridlabd -D tmp=/Users/hipas/.gridlabd/tmp
+bash$ gridlabd --define tmp=/Users/hipas/.gridlabd/tmp
 ~~~
 
 # Description
@@ -22,5 +22,5 @@ Temporary folder name
 # Example
 
 ~~~
-#set tmp=/Users/slacgismo/.gridlabd/tmp
+#set tmp=/Users/hipas/.gridlabd/tmp
 ~~~

--- a/docs/Install/Docker.md
+++ b/docs/Install/Docker.md
@@ -3,8 +3,8 @@
 # Synopsis
 
 ~~~
-bash$ docker pull slacgismo/gridlabd:latest
-bash$ docker run -it -v $(pwd):$(pwd) slacgismo/gridlabd:latest gridlabd -W $(pwd) <...>
+bash$ docker pull hipas/gridlabd:latest
+bash$ docker run -it -v $(pwd):$(pwd) hipas/gridlabd:latest gridlabd -W $(pwd) <...>
 ~~~
 
 # Description
@@ -12,13 +12,13 @@ bash$ docker run -it -v $(pwd):$(pwd) slacgismo/gridlabd:latest gridlabd -W $(pw
 To use the latest version of GridLAB-D with docker, install docker from see www.docker.com. Then run 
 
 ~~~
-bash$ docker pull slacgismo/gridlabd:latest
+bash$ docker pull hipas/gridlabd:latest
 ~~~
 
 For convenience you may tag the image you wish to use by default:
 
 ~~~
-bash$ docker tag slacgismo/gridlabd:latest gridlabd
+bash$ docker tag hipas/gridlabd:latest gridlabd
 ~~~
 
 To get more information about available docker images, see https://hub.docker.com/u/gridlabd/.
@@ -66,7 +66,7 @@ To get a list of available and active docker images:
 ~~~
 bash$ gridlabd --docker status
 REPOSITORY             TAG                 IMAGE ID            CREATED             SIZE
-slacgismo/gridlabd     latest              398e452f9a01        2 days ago          1.56GB
+hipas/gridlabd         latest              398e452f9a01        2 days ago          1.56GB
 gridlabd               latest              398e452f9a01        2 days ago          1.56GB
 ~~~
 
@@ -92,10 +92,10 @@ bash$ docker system prune -a
 
 You can create an image locally with a specific branch (e.g., `develop`) instead of pulling from DockerHub (where the default branch is `master`). 
 
-Firsrt, clone the `https://github.com/slacgismo/gridlabd` and checkout the desired branch (e.g., `develop`). 
+Firsrt, clone the `https://github.com/hipas/gridlabd` and checkout the desired branch (e.g., `develop`). 
 
 ~~~
-bash$ git clone https://github.com/slacgismo/gridlabd -b develop /usr/local/src/gridlabd
+bash$ git clone https://github.com/hipas/gridlabd -b develop /usr/local/src/gridlabd
 ~~~
 
 Then build the image locally: 

--- a/docs/Module/Commercial/CEUS.md
+++ b/docs/Module/Commercial/CEUS.md
@@ -47,7 +47,7 @@
 
 # Description
 
-The CEUS commercial building load model is based on the commercial energy use data collected by Itron for the California Energy Commission. The prepared data files for each California forecasting climate zone (FCZ) are available from the GitHub repository https://github.com/slacgismo/ceus_data in the [`loadshape`](https://github.com/slacgismo/ceus_data/tree/master/loadshape) folder.
+The CEUS commercial building load model is based on the commercial energy use data collected by Itron for the California Energy Commission. The prepared data files for each California forecasting climate zone (FCZ) are available from the GitHub repository https://github.com/hipas/ceus_data in the [`loadshape`](https://github.com/hipas/ceus_data/tree/master/loadshape) folder.
 
 The parent object of a building must be a `powerflow meter` object.  In the absence of a suitable parent object, the building will use the global variables `default_nominal_voltage_A`, `default_nominal_voltage_B`, `default_nominal_voltage_C` and `default_nominal_voltage` to determine the voltage.  The solver will update the meter's power demand value when the load changes.
 
@@ -269,4 +269,4 @@ The temperature, price, and solar sensitivity are not implemented by enduse.  Th
 
 * [[/Module/Commercial]]
 * [California Commercial End-use Survey (CEUS) Website](https://www.energy.ca.gov/ceus)
-* [SLAC GISMo CEUS Data Repository](https://github.com/slacgismo/ceus_data)
+* [SLAC GISMo CEUS Data Repository](https://github.com/hipas/ceus_data)

--- a/docs/Module/Powerflow/Pole.md
+++ b/docs/Module/Powerflow/Pole.md
@@ -173,12 +173,12 @@ Wind speed at pole failure.
 
 # Model
 
-The pole failure model is described in [Pole Loading Model](https://github.com/slacgismo/gridlabd/raw/master/module/powerflow/docs/pole_loading.pdf). 
+The pole failure model is described in [Pole Loading Model](https://github.com/hipas/gridlabd/raw/master/module/powerflow/docs/pole_loading.pdf). 
 
 The pole reaches end of life status based on a degradation rate that is defined by minimum shell thickness of 2". See [Pole Degradation Model](https://www.sciencedirect.com/science/article/pii/S0167473005000457) details.
 
 # See also
 
 * [[/Module/Powerflow/Pole_configuration]]
-* [Pole Loading Model](https://github.com/slacgismo/gridlabd/raw/master/powerflow/docs/pole_loading.pdf)
+* [Pole Loading Model](https://github.com/hipas/gridlabd/raw/master/powerflow/docs/pole_loading.pdf)
 * [Pole Degradation Model](https://www.sciencedirect.com/science/article/pii/S0167473005000457)

--- a/docs/Module/Powerflow/Pole_configuration.md
+++ b/docs/Module/Powerflow/Pole_configuration.md
@@ -30,7 +30,7 @@ GLM:
 
 # Description
 
-The `pole_configuration` object contains information about pole designs, and is referred to by `pole` objects.  See [Pole Loading Model](https://github.com/slacgismo/gridlabd/raw/grip/powerflow/docs/pole_loading.pdf) for details on values for the pole library.
+The `pole_configuration` object contains information about pole designs, and is referred to by `pole` objects.  See [Pole Loading Model](https://github.com/hipas/gridlabd/raw/grip/powerflow/docs/pole_loading.pdf) for details on values for the pole library.
 
 ## Properties
 
@@ -205,6 +205,6 @@ The pole treatment method.
 # See also
 
 * [[/Module/Powerflow/Pole]]
-* [Pole Loading Model](https://github.com/slacgismo/gridlabd/raw/grip/powerflow/docs/pole_loading.pdf)
+* [Pole Loading Model](https://github.com/hipas/gridlabd/raw/grip/powerflow/docs/pole_loading.pdf)
 * [UEP Bulletin 1728F-804](https://www.rd.usda.gov/files/UEP_Bulletin_1728F-804.pdf)
 

--- a/docs/Module/Residential/RBSA.md
+++ b/docs/Module/Residential/RBSA.md
@@ -252,4 +252,4 @@ The temperature, price, and solar sensitivity are not implemented by enduse yet.
 
 * [NEEA Residential Building Stock Assessment](https://neea.org/data/residential-building-stock-assessment)
 
-* [SLAC GISMo RBSA Data Repository](https://github.com/hipas/rbsa_data)
+* [SLAC GISMo RBSA Data Repository](https://github.com/slacgismo/rbsa_data)

--- a/docs/Module/Residential/RBSA.md
+++ b/docs/Module/Residential/RBSA.md
@@ -26,7 +26,7 @@ module residential {
 
 # Description
 
-The RBSA residential building load model is based on the residential building stock assessment energy use data collected by NEAA. The prepared data files are available from the [SLAC Gismo RBSA Data Repository](https://github.com/slacgismo/rbsa_data) in the `csv` folder.
+The RBSA residential building load model is based on the residential building stock assessment energy use data collected by NEAA. The prepared data files are available from the [SLAC Gismo RBSA Data Repository](https://github.com/hipas/rbsa_data) in the `csv` folder.
 
 The parent object of a building must be a `powerflow::meter` object.  In the absence of a suitable parent object, the building will use the global variables `default_nominal_voltage_A`, `default_nominal_voltage_B`, `default_nominal_voltage_C` and `default_nominal_voltage` to determine the voltage.  The solver will update the meter's power demand value when the load changes.
 
@@ -252,4 +252,4 @@ The temperature, price, and solar sensitivity are not implemented by enduse yet.
 
 * [NEEA Residential Building Stock Assessment](https://neea.org/data/residential-building-stock-assessment)
 
-* [SLAC GISMo RBSA Data Repository](https://github.com/slacgismo/rbsa_data)
+* [SLAC GISMo RBSA Data Repository](https://github.com/hipas/rbsa_data)

--- a/docs/News.md
+++ b/docs/News.md
@@ -4,4 +4,4 @@ The HiPAS GridLAB-D Technical Advisory Committee Meetings and User Workshops are
 
 # Recent Updates
 
-A list of recent updates to the master release of HiPAS GridLAB-D may be found at the [GitHub repository](https://github.com/slacgismo/gridlabd/commits/master).
+A list of recent updates to the master release of HiPAS GridLAB-D may be found at the [GitHub repository](https://github.com/hipas/gridlabd/commits/master).

--- a/docs/Resources.md
+++ b/docs/Resources.md
@@ -1,25 +1,25 @@
 The following resources are available to GridLAB-D users.
 
-## [Models](https://github.com/slacgismo/gridlabd-models)
+## [Models](https://github.com/hipas/gridlabd-models)
 
 This GitHub project contains numerous models used in the development, testing, and teaching of GridLAB-D. These models can also serve as examples of how to do some more exotic things using GridLAB-D.
 
-## [Templates](https://github.com/slacgismo/gridlabd-templates)
+## [Templates](https://github.com/hipas/gridlabd-templates)
 
 This GitHub project contains GLM templates that can be configured using CSV inputs to perform specific analyses on models. See [[/Subcommand/Template]] for details.
 
-## [Converters](https://github.com/slacgismo/gridlabd-converters)
+## [Converters](https://github.com/hipas/gridlabd-converters)
 
 This GitHub project contains converters that GridLAB-D uses to accept inputs or generate outputs of various formats. See [[/Converters/README]] for details.
 
-## [Weather](https://github.com/slacgismo/gridlabd-weather)
+## [Weather](https://github.com/hipas/gridlabd-weather)
 
 This GitHub project contains weather data that can be accessed using the `weather` subcommand. See [[/Subcommand/Weather]] for details.
 
-## [Library](https://github.com/slacgismo/gridlabd-library)
+## [Library](https://github.com/hipas/gridlabd-library)
 
 This GitHub project contains libraries of GLM object that can be used in GridLAB-D models. See [[/Subcommand/Library]] for details.
 
-## [Examples](https://github.com/slacgismo/gridlabd-examples)
+## [Examples](https://github.com/hipas/gridlabd-examples)
 
 This GitHub project contains example GLM files that illustrate various ways of using GridLAB-D.

--- a/docs/Server/REST API.md
+++ b/docs/Server/REST API.md
@@ -168,7 +168,7 @@ In the event of an error, the JSON response is of the form
 
 ## Real-time models
 
-Server mode is essential to the realtime mode. Together this allows a web-based application to access the global variable and properties of named objects of a real-time simulation to emulate a control room.  See the [IEEE-123 Model](https://github.com/slacgismo/gridlabd/models/ieee123) for an example.
+Server mode is essential to the realtime mode. Together this allows a web-based application to access the global variable and properties of named objects of a real-time simulation to emulate a control room.  See the [IEEE-123 Model](https://github.com/hipas/gridlabd/models/ieee123) for an example.
 
 # See also
 

--- a/docs/Sponsors.md
+++ b/docs/Sponsors.md
@@ -3,7 +3,7 @@ HiPAS GridLAB-D was developed with funding from the following organizations:
 # California Energy Commission EPIC Program
 [image:cec-logo.png]
 
-The current California version of GridLAB-D is called [HiPAS GridLAB-D 4.2](https://github.com/slacgismo/gridlabd) and is managed by [Stanford University](https://www.stanford.edu/) at [SLAC National Accelerator Laboratory](https://slac.stanford.edu.) under funding from the [California Energy Commission](https://energy.ca.gov/) under the [Electric Program Investment Charge (EPIC) program](https://www.energy.ca.gov/programs-and-topics/programs/electric-program-investment-charge-epic-program).
+The current California version of GridLAB-D is called [HiPAS GridLAB-D 4.2](https://github.com/hipas/gridlabd) and is managed by [Stanford University](https://www.stanford.edu/) at [SLAC National Accelerator Laboratory](https://slac.stanford.edu.) under funding from the [California Energy Commission](https://energy.ca.gov/) under the [Electric Program Investment Charge (EPIC) program](https://www.energy.ca.gov/programs-and-topics/programs/electric-program-investment-charge-epic-program).
 
 # US Department of Energy Office of Electricity
 [image:doe-logo.png]

--- a/docs/Subcommand/Weather.md
+++ b/docs/Subcommand/Weather.md
@@ -249,7 +249,7 @@ bash$ gridlabd weather config show
   GITHUB="https://github.com"
   GITHUBUSERCONTENT="https://raw.githubusercontent.com"
   COUNTRY="US"
-  GITUSER="slacgismo"
+  GITUSER="hipas"
 
   GITREPO="gridlabd-weather"
   GITBRANCH="master"

--- a/gldcore/globals.h
+++ b/gldcore/globals.h
@@ -282,7 +282,7 @@ GLOBAL unsigned char global_no_balance INIT(FALSE);
 GLOBAL char global_kmlfile[1024] INIT(""); /**< Specifies KML file to dump */
 
 /* Variable: global_kmlhost */
-GLOBAL char global_kmlhost[1024] INIT("https://raw.githubusercontent.com/slacgismo/gridlabd/master/gldcore/rt"); /**< Specifies the KML image library server */
+GLOBAL char global_kmlhost[1024] INIT("https://raw.githubusercontent.com/hipas/gridlabd/master/gldcore/rt"); /**< Specifies the KML image library server */
 
 /* Variable: global_modelname */
 GLOBAL char global_modelname[1024] INIT(""); /**< Name of the current model */
@@ -505,7 +505,7 @@ GLOBAL int global_mainloopstate INIT(MLS_INIT); /**< main loop processing state 
 GLOBAL TIMESTAMP global_mainlooppauseat INIT(TS_NEVER); /**< time at which to pause main loop */
 
 /* Variable:  */
-GLOBAL char global_infourl[1024] INIT("http://docs.gridlabd.us/index.html?owner=slacgismo&project=gridlabd&search="); /**< URL for info calls */
+GLOBAL char global_infourl[1024] INIT("http://docs.gridlabd.us/index.html?owner=hipas&project=gridlabd&search="); /**< URL for info calls */
 
 /* Variable:  */
 GLOBAL char global_hostname[1024] INIT("localhost"); /**< machine hostname */

--- a/gldcore/legal.cpp
+++ b/gldcore/legal.cpp
@@ -145,7 +145,7 @@ static pthread_t check_version_thread_id;
 void *check_version_proc(void *ptr)
 {
 	int patch, build;
-	const char *url = "https://raw.githubusercontent.com/slacgismo/gridlabd/master/gldcore/versions.txt";
+	const char *url = "https://raw.githubusercontent.com/hipas/gridlabd/master/gldcore/versions.txt";
 	HTTPRESULT *result = http_read(url,0x1000);
 	char target[32];
 	char *pv = NULL, *nv = NULL;

--- a/gldcore/scripts/gridlabd-contributors
+++ b/gldcore/scripts/gridlabd-contributors
@@ -92,7 +92,7 @@ if not token:
 try:
 	git = github.Github(token)
 
-	repo = git.get_repo("slacgismo/gridlabd")
+	repo = git.get_repo("hipas/gridlabd")
 	for user in repo.get_contributors():
 		if login:
 			output(user.login)

--- a/gldcore/scripts/gridlabd-library
+++ b/gldcore/scripts/gridlabd-library
@@ -10,7 +10,7 @@ fi
 GITHUB="https://github.com"
 GITHUBUSERCONTENT="https://raw.githubusercontent.com"
 ORGANIZATION="US/CA/SLAC"
-GITUSER=slacgismo
+GITUSER=hipas
 GITREPO="gridlabd-library"
 GITBRANCH="master"
 SVNLSOPTIONS="--config-option=servers:global:http-timeout=60 --non-interactive -rHEAD"

--- a/gldcore/scripts/gridlabd-template
+++ b/gldcore/scripts/gridlabd-template
@@ -10,7 +10,7 @@ fi
 GITHUB="https://github.com"
 GITHUBUSERCONTENT="https://raw.githubusercontent.com"
 ORGANIZATION="US/CA/SLAC"
-GITUSER=slacgismo
+GITUSER=hipas
 GITREPO="gridlabd-template"
 GITBRANCH="master"
 DATADIR="$GLD_ETC/template/$ORGANIZATION"

--- a/gldcore/scripts/gridlabd-weather
+++ b/gldcore/scripts/gridlabd-weather
@@ -10,7 +10,7 @@ fi
 GITHUB="https://github.com"
 GITHUBUSERCONTENT="https://raw.githubusercontent.com"
 COUNTRY="US"
-GITUSER=slacgismo
+GITUSER=hipas
 GITREPO="gridlabd-weather"
 GITBRANCH="master"
 DATADIR="$GLD_ETC/weather/$COUNTRY"

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -10,7 +10,7 @@ This PR fixes issue #NUMBER1.
 - [x] List significant code changes
 
 ## Documentation changes
-- [x] [<<<DOCSPEC>>>](http://docs.gridlabd.us/index.html?owner=slacgismo&project=gridlabd&branch=<<<BRANCHNAME>>>&doc=<<<DOCPATHNAME>>>)
+- [x] [<<<DOCSPEC>>>](http://docs.gridlabd.us/index.html?owner=hipas&project=gridlabd&branch=<<<BRANCHNAME>>>&doc=<<<DOCPATHNAME>>>)
 
 ## Test and Validation Notes
 - [x] List changes to existing autotests

--- a/test_markdown.md
+++ b/test_markdown.md
@@ -3916,7 +3916,7 @@
 | object_scan |  | char32 | PUBLIC |  | %[^:]:%d |
 | object_tree_balance |  | bool | PUBLIC |  | FALSE |
 | kmlfile |  | char1024 | PUBLIC |  |  |
-| kmlhost |  | char1024 | PUBLIC |  | https://raw.githubusercontent.com/slacgismo/gridlabd/master/gldcore/rt |
+| kmlhost |  | char1024 | PUBLIC |  | https://raw.githubusercontent.com/hipas/gridlabd/master/gldcore/rt |
 | modelname |  | char1024 | REFERENCE |  | gldcore/converters/autotest/test_markdown.glm |
 | execdir |  | char1024 | REFERENCE |  | /usr/local/opt/gridlabd/4.2.13-201012-develop_add_markdown_output_options/bin |
 | strictnames |  | bool | PUBLIC |  | TRUE |
@@ -3960,7 +3960,7 @@
 | random_number_generator |  | enumeration | PUBLIC | RNG2 RNG3 | RNG3 |
 | mainloop_state |  | enumeration | PUBLIC | INIT RUNNING PAUSED DONE LOCKED | INIT |
 | pauseat |  | timestamp | PUBLIC |  | NEVER |
-| infourl |  | char1024 | PUBLIC |  | http://docs.gridlabd.us/index.html?owner=slacgismo&project=gridlabd&search= |
+| infourl |  | char1024 | PUBLIC |  | http://docs.gridlabd.us/index.html?owner=hipas&project=gridlabd&search= |
 | hostname |  | char1024 | PUBLIC |  | localhost |
 | hostaddr |  | char32 | PUBLIC |  | 127.0.0.1 |
 | autostart_gui |  | bool | PUBLIC |  | TRUE |

--- a/utilities/report.py
+++ b/utilities/report.py
@@ -7,7 +7,7 @@ start = datetime.datetime(now.year,now.month-1,1,0,0,0);
 stop = datetime.datetime(now.year,now.month,1,0,0,0);
 
 # get pulls closed last month
-os.system('curl -s https://api.github.com/repos/slacgismo/gridlabd/pulls\\?state=closed\\&per_page=100\\&sort=updated\\&direction=desc > pulls.json');
+os.system('curl -s https://api.github.com/repos/hipas/gridlabd/pulls\\?state=closed\\&per_page=100\\&sort=updated\\&direction=desc > pulls.json');
 with open("pulls.json","r") as fh:
     pulls = json.load(fh);
     fh.close()
@@ -31,7 +31,7 @@ if os.system('pandoc --listings -o pulls.pdf pulls.md') == 0 :
     os.system('open pulls.pdf');
 
 # get all issues
-os.system('curl -s https://api.github.com/repos/slacgismo/gridlabd/issues\\?state=open\\&per_page=1000\\&sort=created\\&direction=desc > issues.json');
+os.system('curl -s https://api.github.com/repos/hipas/gridlabd/issues\\?state=open\\&per_page=1000\\&sort=created\\&direction=desc > issues.json');
 with open("issues.json","r") as fh:
     issues = json.load(fh);
     fh.close()

--- a/utilities/troubleshooting.awk
+++ b/utilities/troubleshooting.awk
@@ -82,7 +82,7 @@ BEGIN { # this is executed before any files are processed
 			}
 			while ( index($0,"*/") == 0 )
 			
-			info = explanation "<cite>See <a href=\"http://github.com/slacgismo/gridlabd/blob/master/" module "/" filename "#L" tag "\">" id "</a>.</cite>"
+			info = explanation "<cite>See <a href=\"http://github.com/hipas/gridlabd/blob/master/" module "/" filename "#L" tag "\">" id "</a>.</cite>"
 			
 			# add message and TROUBLESHOOT text to appropriate array
 			if ( group == "Warnings" ) {


### PR DESCRIPTION
## Current issues
1. HiPAS (currently forked version of slacgismo) needs to work on separating itself from slacgismo/gridlabd. In order to do so, dependencies on slacgismo's github page were also forked to the hipas account.

## Code changes
- [x] Renames references for GitHub and Docker slacgismo endpoints with the new HiPAS endpoints.